### PR TITLE
hoàn thành task 394.

### DIFF
--- a/AI_Captone_2/ai_service/services/forecasting_service.py
+++ b/AI_Captone_2/ai_service/services/forecasting_service.py
@@ -76,6 +76,13 @@ class ForecastingService:
         # Adapt raw → standardized ds,y
         daily = self._adapter.to_daily_series(raw_df, AdaptConfig(schema=self._schema, hotel=hotel))
 
+        # Fallback Strategy: If hotel data is insufficient, use Global data
+        fallback_used = False
+        if hotel and len(daily) < self._settings.data.min_training_days:
+            daily = self._adapter.to_daily_series(raw_df, AdaptConfig(schema=self._schema, hotel=None))
+            fallback_used = True
+
+
         # Preprocess: continuous daily series
         series = self._preprocessor.make_continuous(
             daily,
@@ -145,14 +152,29 @@ class ForecastingService:
             )
             op_status = DeviationLevel(eval_result["operational_status"])
             deviation_flag = (op_status in [DeviationLevel.WARNING, DeviationLevel.DRIFT])
+            
+            # Map operational status to Confidence string
+            conf_map = {
+                DeviationLevel.NORMAL: "high",
+                DeviationLevel.WARNING: "medium",
+                DeviationLevel.DRIFT: "low",
+            }
+            raw_confidence = conf_map.get(op_status, "medium")
         except Exception as e:
             # Safe fallback if evaluation fails
             deviation_flag = False
+            raw_confidence = "medium"
 
-        # Phase 1: confidence/decision are placeholders (phase 2+)
+        # Apply Fallback Penalty: Downgrade confidence if global fallback was used
+        confidence = raw_confidence
+        if fallback_used:
+            penalty_map = {"high": "medium", "medium": "low", "low": "low"}
+            confidence = penalty_map.get(raw_confidence, "low")
+
+        # Phase 1: decision is placeholder (phase 2+)
         return Phase1Result(
             forecast=forecast_payload,
-            confidence="medium",
+            confidence=confidence,
             deviation=deviation_flag,
             suggested_action="monitor",
             explanation=explanation,


### PR DESCRIPTION
#394

Mo ta Pull Request
- Đã lập trình thuật toán gán nhãn `confidence` tự động từ 3 mức `Normal, Warning, Drift`.
- Xây dựng lớp lá chắn Fallback: Tự động gom dữ liệu Hệ thống (Global) nếu tham số `--hotel` truyền vào gặp khách sạn mới mở hoặc truy vấn sai tên.
- Áp dụng luật Penalty: Tự động trừ đi một cấp độ Confidence (High->Medium, Medium/Low->Low) nếu dùng Fallback để cảnh báo cho khối Quyết định (Decision) phía sau cẩn trọng.

Cac file thay doi
- `ai_service/services/forecasting_service.py`

3. Loai thay doi
- ✨ Tính năng mới (Feature)

4. Checklist
- [x] Confidence biến thiên theo toán học chứ không chết tĩnh ở Medium.
- [x] Bẫy lỗi bảo vệ Server bằng Fallback Data.
- [x] Đã tự chạy kiểm thử bằng command thành công.
