### PR TITLE
Hoan thanh task 396: Gan Decision Core vao Pipeline

### DIFF
--- a/AI_Captone_2/ai_service/services/forecasting_service.py
+++ b/AI_Captone_2/ai_service/services/forecasting_service.py
@@ -21,6 +21,7 @@ from ai_service.evaluation.threshold_policy import ThreeBandThresholds, infer_th
 from ai_service.evaluation.rolling_window import PersistentDeviationConfig
 from ai_service.evaluation.comparison import ComparisonConfig, compare_forecast_with_actual_over_time
 from ai_service.evaluation.error_history_store import ErrorHistoryStoreConfig, save_deviation_history_run
+from ai_service.decision.decision_table import DecisionTable, ConfidenceLevel
 
 
 @dataclass(frozen=True)
@@ -43,6 +44,7 @@ class ForecastingService:
         adapter: Optional[BookingLikeAdapter] = None,
         preprocessor: Optional[ContinuousDailySeriesPreprocessor] = None,
         explainer: Optional[SimpleExplainer] = None,
+        decision: Optional[DecisionTable] = None,
     ) -> None:
         self._settings = settings
         self._schema = schema
@@ -51,6 +53,7 @@ class ForecastingService:
         self._adapter = adapter or BookingLikeAdapter()
         self._preprocessor = preprocessor or ContinuousDailySeriesPreprocessor()
         self._explainer = explainer or SimpleExplainer()
+        self._decision = decision or DecisionTable()
 
     def run_phase1(
         self,
@@ -171,12 +174,16 @@ class ForecastingService:
             penalty_map = {"high": "medium", "medium": "low", "low": "low"}
             confidence = penalty_map.get(raw_confidence, "low")
 
-        # Phase 1: decision is placeholder (phase 2+)
+        # Phase 2: Decision (Map Trend + Confidence)
+        typed_conf: ConfidenceLevel = confidence if confidence in ["high", "medium", "low"] else "medium" # type: ignore
+        trend = self._decision.evaluate_trend(forecast_df)
+        action = self._decision.get_suggested_action(trend=trend, confidence=typed_conf)
+
         return Phase1Result(
             forecast=forecast_payload,
             confidence=confidence,
             deviation=deviation_flag,
-            suggested_action="monitor",
+            suggested_action=action,
             explanation=explanation,
         )
 


### PR DESCRIPTION
#396

### 1. Mô tả Pull Request
- Nạp (Import) Class `DecisionTable` vào Trái tim của Bộ điều phối (ForecastingService).
- Xóa bỏ điểm mù (Mock value `"monitor"`) cuối cùng của Phase 1.
- Tự động lấy điểm dự báo trong 14-30 ngày tới của mô hình AI ném vào hàm Tính Xu Hướng (evaluate_trend).
- Tham chiếu chéo với nhãn Rủi Ro Hiện Tại để trả về kết quả Hành Động Quyết Định sắc bén.

### 2. Các file thay đổi
- `ai_service/services/forecasting_service.py`

### 3. Loại thay đổi
- ✨ Tính năng mới (Feature) / Core Integration

### 4. Checklist (chỉ của task hiện tại)
- [x] Tạo nhánh `task-396-decision-integration` chạy trên nền code Main đã hợp nhất ở Task trước.
- [x] Khấu trừ 100% các biến giả (mock values) của Phase 1.
- [x] Đã sử dụng mã lệnh tự Test (Self-test) và bắt được chữ cảnh báo theo Trend thành công.
